### PR TITLE
feat: 회원가입, 로그인 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,13 +26,13 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+//	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+//	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	//h2

--- a/src/main/java/com/skala/decase/domain/company/controller/CompanyController.java
+++ b/src/main/java/com/skala/decase/domain/company/controller/CompanyController.java
@@ -1,0 +1,34 @@
+package com.skala.decase.domain.company.controller;
+
+import com.skala.decase.domain.company.controller.dto.response.CompanyResponse;
+import com.skala.decase.domain.company.domain.CompanyApiDocument;
+import com.skala.decase.domain.company.service.CompanyService;
+import com.skala.decase.global.model.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Company API", description = "회사 관리를 위한 api 입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/companies")
+public class CompanyController {
+
+    private final CompanyService companyService;
+
+    /**
+     * 회사 이름으로 검색
+     */
+    @PostMapping("/search")
+    @CompanyApiDocument.SearchApiDoc
+    public ResponseEntity<ApiResponse<List<CompanyResponse>>> search(@RequestBody String keyword) {
+        List<CompanyResponse> response = companyService.searchCompaniesByName(keyword);
+        return ResponseEntity.ok().body(ApiResponse.success(response));
+    }
+
+}

--- a/src/main/java/com/skala/decase/domain/company/controller/dto/request/FindCompanyRequest.java
+++ b/src/main/java/com/skala/decase/domain/company/controller/dto/request/FindCompanyRequest.java
@@ -1,0 +1,11 @@
+package com.skala.decase.domain.company.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FindCompanyRequest(
+
+        @NotBlank(message = "키워드를 입력해 주세요.")
+        String keyword
+
+) {
+}

--- a/src/main/java/com/skala/decase/domain/company/controller/dto/response/CompanyResponse.java
+++ b/src/main/java/com/skala/decase/domain/company/controller/dto/response/CompanyResponse.java
@@ -1,0 +1,7 @@
+package com.skala.decase.domain.company.controller.dto.response;
+
+public record CompanyResponse(
+        long companyId,
+        String name
+) {
+}

--- a/src/main/java/com/skala/decase/domain/company/domain/CompanyApiDocument.java
+++ b/src/main/java/com/skala/decase/domain/company/domain/CompanyApiDocument.java
@@ -1,0 +1,35 @@
+package com.skala.decase.domain.company.domain;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Tag(name = "company API", description = "회사 관리를 위한 api 입니다.")
+public @interface CompanyApiDocument {
+
+    @Operation(summary = "검색", description = "검색입니다..")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "검색 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "회사를 찾을 수 없습니다.",
+                            value = "{\"code\": 404, \"message\": \"회사를 찾을 수 없습니다.\"}"),
+                            @ExampleObject(name = "부서를 찾을 수 없습니다.",
+                                    value = "{\"code\": 404, \"message\": \"부서를 찾을 수 없습니다.\"}"),
+                    }
+            )),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SearchApiDoc {
+    }
+
+}

--- a/src/main/java/com/skala/decase/domain/company/exception/CompanyException.java
+++ b/src/main/java/com/skala/decase/domain/company/exception/CompanyException.java
@@ -1,0 +1,10 @@
+package com.skala.decase.domain.company.exception;
+
+import com.skala.decase.global.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class CompanyException extends CustomException {
+    public CompanyException(String message, HttpStatus status) {
+        super(message, status);
+    }
+}

--- a/src/main/java/com/skala/decase/domain/company/mapper/CompanyMapper.java
+++ b/src/main/java/com/skala/decase/domain/company/mapper/CompanyMapper.java
@@ -1,0 +1,19 @@
+package com.skala.decase.domain.company.mapper;
+
+import com.skala.decase.domain.company.controller.dto.response.CompanyResponse;
+import com.skala.decase.domain.company.domain.Company;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+public class CompanyMapper {
+
+    public CompanyResponse toResponse(Company company) {
+        return new CompanyResponse(
+                company.getCompanyId(),
+                company.getName()
+        );
+    }
+
+}

--- a/src/main/java/com/skala/decase/domain/company/repository/CompanyRepository.java
+++ b/src/main/java/com/skala/decase/domain/company/repository/CompanyRepository.java
@@ -1,0 +1,15 @@
+package com.skala.decase.domain.company.repository;
+
+import com.skala.decase.domain.company.domain.Company;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CompanyRepository extends JpaRepository<Company, Long> {
+
+    @Query("SELECT c FROM Company c WHERE  c.name LIKE %:name%")
+    List<Company> findByKeyword(@Param("name") String name);
+}

--- a/src/main/java/com/skala/decase/domain/company/service/CompanyService.java
+++ b/src/main/java/com/skala/decase/domain/company/service/CompanyService.java
@@ -1,0 +1,30 @@
+package com.skala.decase.domain.company.service;
+
+import com.skala.decase.domain.company.controller.dto.response.CompanyResponse;
+import com.skala.decase.domain.company.domain.Company;
+import com.skala.decase.domain.company.mapper.CompanyMapper;
+import com.skala.decase.domain.company.repository.CompanyRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CompanyService {
+
+    private final CompanyRepository companyRepository;
+    private final CompanyMapper companyMapper;
+
+    /**
+     * 회사 이름 키워드로 검색
+     *
+     * @param keyword 키워드
+     * @return 검색된 회사 리스트
+     */
+    public List<CompanyResponse> searchCompaniesByName(String keyword) {
+        List<Company> companyList = companyRepository.findByKeyword(keyword);
+        return companyList.stream().map(companyMapper::toResponse).toList();
+    }
+}

--- a/src/main/java/com/skala/decase/domain/department/controller/DepartmentController.java
+++ b/src/main/java/com/skala/decase/domain/department/controller/DepartmentController.java
@@ -1,0 +1,36 @@
+package com.skala.decase.domain.department.controller;
+
+import com.skala.decase.domain.company.domain.CompanyApiDocument;
+import com.skala.decase.domain.department.controller.dto.request.FindDepartmentRequest;
+import com.skala.decase.domain.department.controller.dto.response.DepartmentResponse;
+import com.skala.decase.domain.department.service.DepartmentService;
+import com.skala.decase.global.model.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Department API", description = "부서 관리를 위한 api 입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/departments")
+public class DepartmentController {
+
+    private final DepartmentService departmentService;
+
+    /**
+     * 회사 이름으로 검색
+     */
+    @PostMapping("/search")
+    @CompanyApiDocument.SearchApiDoc
+    public ResponseEntity<ApiResponse<List<DepartmentResponse>>> search(@RequestBody FindDepartmentRequest request) {
+        List<DepartmentResponse> response = departmentService.searchDepartmentsByName(request.companyId(),
+                request.keyword());
+        return ResponseEntity.ok().body(ApiResponse.success(response));
+    }
+
+}

--- a/src/main/java/com/skala/decase/domain/department/controller/dto/request/FindDepartmentRequest.java
+++ b/src/main/java/com/skala/decase/domain/department/controller/dto/request/FindDepartmentRequest.java
@@ -1,0 +1,14 @@
+package com.skala.decase.domain.department.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FindDepartmentRequest(
+
+        @NotBlank(message = "회사 식별자를 입력해주세요.")
+        long companyId,
+
+        @NotBlank(message = "키워드를 입력해 주세요.")
+        String keyword
+
+) {
+}

--- a/src/main/java/com/skala/decase/domain/department/controller/dto/response/DepartmentResponse.java
+++ b/src/main/java/com/skala/decase/domain/department/controller/dto/response/DepartmentResponse.java
@@ -1,0 +1,8 @@
+package com.skala.decase.domain.department.controller.dto.response;
+
+public record DepartmentResponse(
+        long companyId,
+        long departmentId,
+        String name
+) {
+}

--- a/src/main/java/com/skala/decase/domain/department/domain/DepartmentApiDocument.java
+++ b/src/main/java/com/skala/decase/domain/department/domain/DepartmentApiDocument.java
@@ -1,0 +1,35 @@
+package com.skala.decase.domain.department.domain;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Tag(name = "department API", description = "부서 관리를 위한 api 입니다.")
+public @interface DepartmentApiDocument {
+
+    @Operation(summary = "검색", description = "검색입니다..")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "검색 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "회사를 찾을 수 없습니다.",
+                            value = "{\"code\": 404, \"message\": \"회사를 찾을 수 없습니다.\"}"),
+                            @ExampleObject(name = "부서를 찾을 수 없습니다.",
+                                    value = "{\"code\": 404, \"message\": \"부서를 찾을 수 없습니다.\"}"),
+                    }
+            )),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SearchApiDoc {
+    }
+
+}

--- a/src/main/java/com/skala/decase/domain/department/exception/DepartmentException.java
+++ b/src/main/java/com/skala/decase/domain/department/exception/DepartmentException.java
@@ -1,0 +1,10 @@
+package com.skala.decase.domain.department.exception;
+
+import com.skala.decase.global.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class DepartmentException extends CustomException {
+    public DepartmentException(String message, HttpStatus status) {
+        super(message, status);
+    }
+}

--- a/src/main/java/com/skala/decase/domain/department/mapper/DepartmentMapper.java
+++ b/src/main/java/com/skala/decase/domain/department/mapper/DepartmentMapper.java
@@ -1,0 +1,20 @@
+package com.skala.decase.domain.department.mapper;
+
+import com.skala.decase.domain.department.controller.dto.response.DepartmentResponse;
+import com.skala.decase.domain.department.domain.Department;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+public class DepartmentMapper {
+
+    public DepartmentResponse toResponse(Department department) {
+        return new DepartmentResponse(
+                department.getCompany().getCompanyId(),
+                department.getDepartmentId(),
+                department.getName()
+        );
+    }
+
+}

--- a/src/main/java/com/skala/decase/domain/department/repository/DepartmentRepository.java
+++ b/src/main/java/com/skala/decase/domain/department/repository/DepartmentRepository.java
@@ -1,0 +1,15 @@
+package com.skala.decase.domain.department.repository;
+
+import com.skala.decase.domain.department.domain.Department;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DepartmentRepository extends JpaRepository<Department, Long> {
+
+    @Query("SELECT d FROM Department d WHERE d.company.companyId = :companyId AND d.name LIKE %:name%")
+    List<Department> findByCompanyIdAndNameContaining(@Param("companyId") Long companyId, @Param("name") String name);
+}

--- a/src/main/java/com/skala/decase/domain/department/service/DepartmentService.java
+++ b/src/main/java/com/skala/decase/domain/department/service/DepartmentService.java
@@ -1,0 +1,32 @@
+package com.skala.decase.domain.department.service;
+
+import com.skala.decase.domain.department.controller.dto.response.DepartmentResponse;
+import com.skala.decase.domain.department.domain.Department;
+import com.skala.decase.domain.department.mapper.DepartmentMapper;
+import com.skala.decase.domain.department.repository.DepartmentRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DepartmentService {
+
+    private final DepartmentRepository departmentRepository;
+
+    private final DepartmentMapper departmentMapper;
+
+    /**
+     * 회사 이름 키워드로 검색
+     *
+     * @param keyword 키워드
+     * @return 검색된 부서 리스트
+     */
+    public List<DepartmentResponse> searchDepartmentsByName(long companyId, String keyword) {
+
+        List<Department> departmentList = departmentRepository.findByCompanyIdAndNameContaining(companyId, keyword);
+        return departmentList.stream().map(departmentMapper::toResponse).toList();
+    }
+}

--- a/src/main/java/com/skala/decase/domain/member/controller/AuthController.java
+++ b/src/main/java/com/skala/decase/domain/member/controller/AuthController.java
@@ -1,0 +1,51 @@
+package com.skala.decase.domain.member.controller;
+
+import com.skala.decase.domain.member.controller.dto.request.LogInRequest;
+import com.skala.decase.domain.member.controller.dto.request.SignUpRequest;
+import com.skala.decase.domain.member.controller.dto.response.MemberResponse;
+import com.skala.decase.domain.member.domain.AuthApiDocument;
+import com.skala.decase.domain.member.service.AuthService;
+import com.skala.decase.global.model.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth API", description = "로그인/회원가입 관리를 위한 api 입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    /**
+     * 회원가입
+     *
+     * @param request
+     * @return
+     */
+    @PostMapping("/signup")
+    @AuthApiDocument.SignUpApiDoc
+    public ResponseEntity<ApiResponse<String>> signUp(@RequestBody SignUpRequest request) {
+        authService.signUp(request);
+        return ResponseEntity.ok().body(ApiResponse.created("회원가입 성공"));
+    }
+
+    /**
+     * 로그인
+     *
+     * @param request
+     * @return
+     */
+    @PostMapping("/login")
+    @AuthApiDocument.LoginApiDoc
+    public ResponseEntity<ApiResponse<MemberResponse>> login(@RequestBody LogInRequest request) {
+        MemberResponse response = authService.login(request);
+        return ResponseEntity.ok().body(ApiResponse.success(response));
+    }
+
+}

--- a/src/main/java/com/skala/decase/domain/member/controller/dto/request/LogInRequest.java
+++ b/src/main/java/com/skala/decase/domain/member/controller/dto/request/LogInRequest.java
@@ -1,0 +1,18 @@
+package com.skala.decase.domain.member.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record LogInRequest(
+
+        @NotBlank(message = "아이디를 입력해주세요.")
+        String id,
+
+        @Pattern(
+                regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\W).{8,16}$",
+                message = "비밀번호는 8~16자 이내이며, 대문자, 소문자, 특수문자를 포함해야 합니다."
+        )
+        @NotBlank(message = "비밀번호를 입력해 주세요.")
+        String password
+
+) {}

--- a/src/main/java/com/skala/decase/domain/member/controller/dto/request/SignUpRequest.java
+++ b/src/main/java/com/skala/decase/domain/member/controller/dto/request/SignUpRequest.java
@@ -1,0 +1,36 @@
+package com.skala.decase.domain.member.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record SignUpRequest(
+
+        @NotBlank(message = "아이디를 입력해주세요.")
+        String id,
+
+        @Pattern(
+                regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\W).{8,16}$",
+                message = "비밀번호는 8~16자 이내이며, 대문자, 소문자, 특수문자를 포함해야 합니다."
+        )
+        @NotBlank(message = "비밀번호를 입력해 주세요.")
+        String password,
+
+        @NotBlank(message = "이름을 입력해주세요.")
+        String name,
+
+        @Schema(example = "decase@skala.ac.kr")
+        @Pattern(
+                regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$",
+                message = "이메일 형식에 맞지 않습니다."
+        )
+        @NotBlank(message = "이메일을 입력해주세요.")
+        String email,
+
+        @Schema(description = "회사 식별자", example = "1")
+        long companyId,
+
+        @Schema(description = "부서 식별자", example = "1")
+        long departmentId
+
+) {}

--- a/src/main/java/com/skala/decase/domain/member/controller/dto/response/MemberResponse.java
+++ b/src/main/java/com/skala/decase/domain/member/controller/dto/response/MemberResponse.java
@@ -1,0 +1,11 @@
+package com.skala.decase.domain.member.controller.dto.response;
+
+public record MemberResponse(
+        long memberId,
+        String id,
+        String name,
+        String email,
+        String companyName,
+        String departmentName
+) {
+}

--- a/src/main/java/com/skala/decase/domain/member/domain/AuthApiDocument.java
+++ b/src/main/java/com/skala/decase/domain/member/domain/AuthApiDocument.java
@@ -1,0 +1,47 @@
+package com.skala.decase.domain.member.domain;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Tag(name = "Auth API", description = "로그인/회원가입 관리를 위한 api 입니다.")
+public @interface AuthApiDocument {
+
+    @Operation(summary = "회원가입", description = "회원가입입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "회원가입 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json",
+                    examples = {@ExampleObject(name = "회사를 찾을 수 없습니다.",
+                            value = "{\"code\": 404, \"message\": \"회사를 찾을 수 없습니다.\"}"),
+                            @ExampleObject(name = "부서를 찾을 수 없습니다.",
+                                    value = "{\"code\": 404, \"message\": \"부서를 찾을 수 없습니다.\"}"),
+                    }
+            )),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SignUpApiDoc {
+    }
+
+    @Operation(summary = "로그인", description = "로그인 입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface LoginApiDoc {
+    }
+
+}

--- a/src/main/java/com/skala/decase/domain/member/domain/Member.java
+++ b/src/main/java/com/skala/decase/domain/member/domain/Member.java
@@ -50,4 +50,14 @@ public class Member {
 
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
     private List<MemberProject> membersProjects;
+
+    // 회원가입 용 생성자
+    public Member(String id, String password, String name, String email, Company company, Department department) {
+        this.id = id;
+        this.password = password;
+        this.name = name;
+        this.email = email;
+        this.company = company;
+        this.department = department;
+    }
 }

--- a/src/main/java/com/skala/decase/domain/member/exception/MemberException.java
+++ b/src/main/java/com/skala/decase/domain/member/exception/MemberException.java
@@ -1,0 +1,10 @@
+package com.skala.decase.domain.member.exception;
+
+import com.skala.decase.global.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class MemberException extends CustomException {
+    public MemberException(String message, HttpStatus status) {
+        super(message, status);
+    }
+}

--- a/src/main/java/com/skala/decase/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/skala/decase/domain/member/mapper/MemberMapper.java
@@ -1,0 +1,37 @@
+package com.skala.decase.domain.member.mapper;
+
+import com.skala.decase.domain.company.domain.Company;
+import com.skala.decase.domain.department.domain.Department;
+import com.skala.decase.domain.member.controller.dto.request.SignUpRequest;
+import com.skala.decase.domain.member.controller.dto.response.MemberResponse;
+import com.skala.decase.domain.member.domain.Member;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+public class MemberMapper {
+
+    public Member toEntity(SignUpRequest request, Company company, Department department) {
+        return new Member(
+                request.id(),
+                request.password(),
+                request.name(),
+                request.email(),
+                company,
+                department
+        );
+    }
+
+    public MemberResponse toResponse(Member member) {
+        return new MemberResponse(
+                member.getMemberId(),
+                member.getId(),
+                member.getName(),
+                member.getEmail(),
+                member.getCompany().getName(),
+                member.getDepartment().getName()
+        );
+    }
+
+}

--- a/src/main/java/com/skala/decase/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/skala/decase/domain/member/repository/MemberRepository.java
@@ -1,0 +1,14 @@
+package com.skala.decase.domain.member.repository;
+
+import com.skala.decase.domain.member.domain.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    @Query("select m from Member m where m.id =:id")
+    Optional<Member> findById(@Param("id") String id);
+}

--- a/src/main/java/com/skala/decase/domain/member/service/AuthService.java
+++ b/src/main/java/com/skala/decase/domain/member/service/AuthService.java
@@ -1,0 +1,64 @@
+package com.skala.decase.domain.member.service;
+
+import com.skala.decase.domain.company.domain.Company;
+import com.skala.decase.domain.company.exception.CompanyException;
+import com.skala.decase.domain.company.repository.CompanyRepository;
+import com.skala.decase.domain.department.domain.Department;
+import com.skala.decase.domain.department.exception.DepartmentException;
+import com.skala.decase.domain.department.repository.DepartmentRepository;
+import com.skala.decase.domain.member.controller.dto.request.LogInRequest;
+import com.skala.decase.domain.member.controller.dto.request.SignUpRequest;
+import com.skala.decase.domain.member.controller.dto.response.MemberResponse;
+import com.skala.decase.domain.member.domain.Member;
+import com.skala.decase.domain.member.exception.MemberException;
+import com.skala.decase.domain.member.mapper.MemberMapper;
+import com.skala.decase.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final CompanyRepository companyRepository;
+    private final DepartmentRepository departmentRepository;
+
+    private final MemberMapper memberMapper;
+
+    /**
+     * 회원가입
+     * @param request 회원가입 요청 객체
+     */
+    @Transactional
+    public void signUp(SignUpRequest request) {
+        Company company = companyRepository.findById(request.companyId())
+                .orElseThrow(() -> new CompanyException("회사를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        Department department = departmentRepository.findById(request.departmentId())
+                .orElseThrow(() -> new DepartmentException("부서를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        Member member = memberMapper.toEntity(request, company, department);
+
+        memberRepository.save(member);
+    }
+
+    /**
+     * 로그인
+     * @param request 로그인 요청 객체
+     * @return member 사용자 객체
+     */
+    public MemberResponse login(LogInRequest request) {
+        Member member = memberRepository.findById(request.id())
+                .orElseThrow(() -> new MemberException("해당 사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        if (!member.getPassword().equals(request.password())) {
+            throw new MemberException("비밀번호 불일치", HttpStatus.BAD_REQUEST);
+        }
+
+        return memberMapper.toResponse(member);
+    }
+}


### PR DESCRIPTION
## ✨ 개요
회원가입, 로그인 기능입니다.
회원가입 시에 사용자는 소속 회사, 부서를 입력해야 합니다.

## ✅ 작업 내용
- [x] 회원가입 api
- [x] 로그인 api
- [x] 회사 이름으로 검색 api
- [x] 부서 이름으로 검색 api

## 🔍 관련 이슈
#6 

## 🙋🏻 기타 참고 사항
security login 창으로 바로 넘어가서 임시로 security 관련 의존성들을 주석처리했습니다.
회사 이름으로 검색 api는 동작이 안됩니당..ㅎ
