### PR TITLE
Feat/memberProject: Admin 제약 추가

### DIFF
--- a/.env.properties
+++ b/.env.properties
@@ -1,7 +1,7 @@
 # Database
-MARIA_DATABASE_URL=jdbc:mariadb://localhost:3306/DECASE
+MARIA_DATABASE_URL=jdbc:mariadb://localhost:3306/decase_db
 MARIA_USER=root
-MARIA_PASSWORD=0413
+MARIA_PASSWORD=0223
 
 # Ports
 MYSQL_PORT=3306
@@ -9,3 +9,7 @@ MARIADB_PORT=3306
 
 # Timezone
 TZ=Asia/Seoul
+
+# Mail
+MAIL_ADDRESS = goguma7997@gmail.com
+MAIL_PASSWORD = gpqcikbozlxofkfz

--- a/src/main/java/com/skala/decase/domain/project/controller/ProjectMemberController.java
+++ b/src/main/java/com/skala/decase/domain/project/controller/ProjectMemberController.java
@@ -2,6 +2,7 @@ package com.skala.decase.domain.project.controller;
 
 import com.skala.decase.domain.project.controller.dto.request.ChangeStatusRequest;
 import com.skala.decase.domain.project.controller.dto.request.CreateMemberProjectRequest;
+import com.skala.decase.domain.project.controller.dto.request.DeleteMemberInvitationRequest;
 import com.skala.decase.domain.project.controller.dto.response.*;
 import com.skala.decase.domain.project.service.ProjectInvitationService;
 import com.skala.decase.global.model.ApiResponse;
@@ -85,5 +86,13 @@ public class ProjectMemberController {
         List<MemberInvitationResponse> responses = projectInvitationService.findMemberInvitationByProject(projectId);
         return ResponseEntity.ok()
                 .body(ApiResponse.success(responses));
+    }
+
+    @Operation(summary = "프로젝트 초대 삭제", description = "프로젝트 초대를 삭제하는 API입니다.")
+    @DeleteMapping("/{projectId}/members/invitation/cancel")
+    public ResponseEntity<ApiResponse<DeleteMemberResponse>> deleteInvitation(@PathVariable("projectId") long projectId, @RequestBody DeleteMemberInvitationRequest request) {
+        DeleteMemberResponse response = projectInvitationService.deleteMemberInvitation(projectId, request);
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/skala/decase/domain/project/controller/ProjectMemberController.java
+++ b/src/main/java/com/skala/decase/domain/project/controller/ProjectMemberController.java
@@ -3,6 +3,7 @@ package com.skala.decase.domain.project.controller;
 import com.skala.decase.domain.project.controller.dto.request.ChangeStatusRequest;
 import com.skala.decase.domain.project.controller.dto.request.CreateMemberProjectRequest;
 import com.skala.decase.domain.project.controller.dto.request.DeleteMemberInvitationRequest;
+import com.skala.decase.domain.project.controller.dto.request.DeleteMemberRequest;
 import com.skala.decase.domain.project.controller.dto.response.*;
 import com.skala.decase.domain.project.service.ProjectInvitationService;
 import com.skala.decase.global.model.ApiResponse;
@@ -73,9 +74,9 @@ public class ProjectMemberController {
     }
 
     @Operation(summary = "프로젝트 멤버 삭제", description = "프로젝트 멤버 삭제를 위한 API입니다.")
-    @DeleteMapping("/{projectId}/members/{memberId}")
-    public ResponseEntity<ApiResponse<DeleteMemberResponse>> deleteMember(@PathVariable("projectId") long projectId, @PathVariable("memberId") String memberId) {
-        DeleteMemberResponse response = projectInvitationService.deleteMember(projectId, memberId);
+    @DeleteMapping("/{projectId}/members")
+    public ResponseEntity<ApiResponse<DeleteMemberResponse>> deleteMember(@PathVariable("projectId") long projectId, @RequestBody DeleteMemberRequest request) {
+        DeleteMemberResponse response = projectInvitationService.deleteMember(projectId, request);
         return ResponseEntity.ok()
                 .body(ApiResponse.success(response));
     }

--- a/src/main/java/com/skala/decase/domain/project/controller/dto/request/ChangeStatusRequest.java
+++ b/src/main/java/com/skala/decase/domain/project/controller/dto/request/ChangeStatusRequest.java
@@ -3,6 +3,7 @@ package com.skala.decase.domain.project.controller.dto.request;
 import com.skala.decase.domain.project.domain.Permission;
 
 public record ChangeStatusRequest(
+        long adminId,
         Permission permission
 ) {
 }

--- a/src/main/java/com/skala/decase/domain/project/controller/dto/request/CreateMemberProjectRequest.java
+++ b/src/main/java/com/skala/decase/domain/project/controller/dto/request/CreateMemberProjectRequest.java
@@ -5,6 +5,9 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record CreateMemberProjectRequest(
+        @NotBlank(message = "Admin의 Id를 입력해주세요.")
+        long adminId,
+
         @NotBlank(message = "초대할 이메일을 입력해주세요.")
         @Size(max = 50, message = "이메일은 50자 이하로 제한합니다.")
         String email,

--- a/src/main/java/com/skala/decase/domain/project/controller/dto/request/DeleteMemberInvitationRequest.java
+++ b/src/main/java/com/skala/decase/domain/project/controller/dto/request/DeleteMemberInvitationRequest.java
@@ -1,0 +1,8 @@
+package com.skala.decase.domain.project.controller.dto.request;
+
+public record DeleteMemberInvitationRequest(
+        long adminId,
+        String email,
+        String token
+) {
+}

--- a/src/main/java/com/skala/decase/domain/project/controller/dto/request/DeleteMemberRequest.java
+++ b/src/main/java/com/skala/decase/domain/project/controller/dto/request/DeleteMemberRequest.java
@@ -1,7 +1,7 @@
 package com.skala.decase.domain.project.controller.dto.request;
 
-public record DeleteMemberInvitationRequest(
+public record DeleteMemberRequest(
         long adminId,
-        String email
+        String memberId
 ) {
 }

--- a/src/main/java/com/skala/decase/domain/project/controller/dto/response/MemberProjectResponse.java
+++ b/src/main/java/com/skala/decase/domain/project/controller/dto/response/MemberProjectResponse.java
@@ -8,6 +8,7 @@ public record MemberProjectResponse(
         String name,
         String company,
         String department,
-        Permission permission
+        Permission permission,
+        boolean isAdmin
 ) {
 }

--- a/src/main/java/com/skala/decase/domain/project/mapper/ProjectMemberMapper.java
+++ b/src/main/java/com/skala/decase/domain/project/mapper/ProjectMemberMapper.java
@@ -28,6 +28,10 @@ public class ProjectMemberMapper {
         return new DeleteMemberResponse("멤버가 정상적으로 삭제되었습니다.");
     }
 
+    public DeleteMemberResponse deleteInvitationSuccess() {
+        return new DeleteMemberResponse("초대가 정상적으로 삭제되었습니다.");
+    }
+
     public MemberInvitationResponse toInvite(ProjectInvitation projectInvitation) {
         return new MemberInvitationResponse(
                 projectInvitation.getEmail(),

--- a/src/main/java/com/skala/decase/domain/project/mapper/ProjectMemberMapper.java
+++ b/src/main/java/com/skala/decase/domain/project/mapper/ProjectMemberMapper.java
@@ -19,7 +19,8 @@ public class ProjectMemberMapper {
                 memberProject.getMember().getName(),
                 memberProject.getMember().getCompany().getName(),
                 memberProject.getMember().getCompany().getName(),
-                memberProject.getPermission()
+                memberProject.getPermission(),
+                memberProject.isAdmin()
         );
     }
 

--- a/src/main/java/com/skala/decase/domain/project/repository/ProjectInvitationRepository.java
+++ b/src/main/java/com/skala/decase/domain/project/repository/ProjectInvitationRepository.java
@@ -5,6 +5,7 @@ import com.skala.decase.domain.project.domain.ProjectInvitation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProjectInvitationRepository extends JpaRepository<ProjectInvitation, Long> {
     ProjectInvitation findByToken(String token);
@@ -13,5 +14,5 @@ public interface ProjectInvitationRepository extends JpaRepository<ProjectInvita
 
     List<ProjectInvitation> findAllByProject(Project project);
 
-    ProjectInvitation findByProjectAndEmail(Project project, String email);
+    Optional<ProjectInvitation> findFirstByProjectAndEmailOrderByExpiryDateDesc(Project project, String email);
 }

--- a/src/main/java/com/skala/decase/domain/project/repository/ProjectInvitationRepository.java
+++ b/src/main/java/com/skala/decase/domain/project/repository/ProjectInvitationRepository.java
@@ -13,4 +13,5 @@ public interface ProjectInvitationRepository extends JpaRepository<ProjectInvita
 
     List<ProjectInvitation> findAllByProject(Project project);
 
+    ProjectInvitation findByProjectAndEmail(Project project, String email);
 }

--- a/src/main/java/com/skala/decase/domain/project/service/ProjectInvitationService.java
+++ b/src/main/java/com/skala/decase/domain/project/service/ProjectInvitationService.java
@@ -105,6 +105,14 @@ public class ProjectInvitationService {
     public MemberProjectResponse updateMemberStatus(long projectId, String memberId, ChangeStatusRequest request) {
         MemberProject memberProject = memberProjectRepository.findByProjectIdAndId(projectId, memberId)
                 .orElseThrow(() -> new ProjectException("해당 프로젝트에 멤버가 존재하지 않습니다.", HttpStatus.NOT_FOUND));
+        MemberProject adminMemberProject = memberProjectRepository.findByProjectIdAndMemberId(projectId, request.adminId());
+
+        if (!adminMemberProject.isAdmin()) {
+            throw new ProjectException("초대 권한이 없습니다.", HttpStatus.BAD_REQUEST);
+        }
+        if (adminMemberProject.getMember().getId().equals(memberId)) {
+            throw new ProjectException("Admin의 권한을 변경할 수 없습니다.", HttpStatus.BAD_REQUEST);
+        }
 
         memberProject.setPermission(request.permission());
         memberProjectRepository.save(memberProject);

--- a/src/main/java/com/skala/decase/domain/project/service/ProjectInvitationService.java
+++ b/src/main/java/com/skala/decase/domain/project/service/ProjectInvitationService.java
@@ -6,6 +6,7 @@ import com.skala.decase.domain.member.service.MemberService;
 import com.skala.decase.domain.project.controller.dto.request.ChangeStatusRequest;
 import com.skala.decase.domain.project.controller.dto.request.CreateMemberProjectRequest;
 import com.skala.decase.domain.project.controller.dto.request.DeleteMemberInvitationRequest;
+import com.skala.decase.domain.project.controller.dto.request.DeleteMemberRequest;
 import com.skala.decase.domain.project.controller.dto.response.*;
 import com.skala.decase.domain.project.domain.MemberProject;
 import com.skala.decase.domain.project.domain.Project;
@@ -38,6 +39,19 @@ public class ProjectInvitationService {
 
     public CreateMemberProjectResponse createInvitation(long projectId, CreateMemberProjectRequest request) {
         Project project = projectService.findByProjectId(projectId);
+        MemberProject adminMemberProject = memberProjectRepository.findByProjectIdAndMemberId(projectId, request.adminId());
+        if (adminMemberProject == null) {
+            throw new ProjectException("권한이 없습니다.", HttpStatus.BAD_REQUEST);
+        }
+        if (adminMemberProject.getMember().getEmail().equals(request.email())) {
+            throw new ProjectException("Admin에게 초대를 발송할 수 없습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        ProjectInvitation preProjectInvitation = projectInvitationRepository.findFirstByProjectAndEmailOrderByExpiryDateDesc(project, request.email())
+                .orElse(null);
+        if (preProjectInvitation != null && !preProjectInvitation.isExpired()) {
+            throw new ProjectException("이미 초대를 전송했습니다.", HttpStatus.BAD_REQUEST);
+        }
 
         ProjectInvitation projectInvitation = ProjectInvitation.builder()
                 .email(request.email())
@@ -45,6 +59,7 @@ public class ProjectInvitationService {
                 .permission(request.permission())
                 .project(project)
                 .build();
+
         mailService.sendMail(projectInvitation);
         projectInvitationRepository.save(projectInvitation);
 
@@ -107,10 +122,10 @@ public class ProjectInvitationService {
                 .orElseThrow(() -> new ProjectException("해당 프로젝트에 멤버가 존재하지 않습니다.", HttpStatus.NOT_FOUND));
         MemberProject adminMemberProject = memberProjectRepository.findByProjectIdAndMemberId(projectId, request.adminId());
 
-        if (!adminMemberProject.isAdmin()) {
-            throw new ProjectException("초대 권한이 없습니다.", HttpStatus.BAD_REQUEST);
+        if (adminMemberProject == null || !adminMemberProject.isAdmin()) {
+            throw new ProjectException("수정 권한이 없습니다.", HttpStatus.BAD_REQUEST);
         }
-        if (adminMemberProject.getMember().getId().equals(memberId)) {
+        if (memberProject.isAdmin()) {
             throw new ProjectException("Admin의 권한을 변경할 수 없습니다.", HttpStatus.BAD_REQUEST);
         }
 
@@ -119,35 +134,44 @@ public class ProjectInvitationService {
         return projectMemberMapper.toResponse(memberProject);
     }
 
-    public DeleteMemberResponse deleteMember(long projectId, String memberId) {
-        MemberProject memberProject = memberProjectRepository.findByProjectIdAndId(projectId, memberId)
+    public DeleteMemberResponse deleteMember(long projectId, DeleteMemberRequest request) {
+        MemberProject memberProject = memberProjectRepository.findByProjectIdAndId(projectId, request.memberId())
                 .orElseThrow(() -> new ProjectException("해당 프로젝트에 멤버가 존재하지 않습니다.", HttpStatus.NOT_FOUND));
+        MemberProject adminMemberProject = memberProjectRepository.findByProjectIdAndMemberId(projectId, request.adminId());
+        if (adminMemberProject == null || !adminMemberProject.isAdmin()) {
+            throw new ProjectException("권한이 없습니다.", HttpStatus.BAD_REQUEST);
+        }
+        if (memberProject.isAdmin()) {
+            throw new ProjectException("Admin을 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST);
+        }
+
         memberProjectRepository.delete(memberProject);
         return projectMemberMapper.deleteSuccess();
     }
 
     public List<MemberInvitationResponse> findMemberInvitationByProject(long projectId) {
         Project project = projectService.findByProjectId(projectId);
-        List<ProjectInvitation> projectInvitations = projectInvitationRepository.findAllByProject(project);
+        List<ProjectInvitation> projectInvitations = projectInvitationRepository.findAllByProject(project)
+                .stream().filter(projectInvitation -> !projectInvitation.isExpired()).toList();
 
         return projectInvitations.stream().map(projectMemberMapper::toInvite).toList();
     }
 
     public DeleteMemberResponse deleteMemberInvitation(long projectId, DeleteMemberInvitationRequest request) {
-        MemberProject memberProject = memberProjectRepository.findByProjectIdAndMemberId(projectId, request.adminId());
-        ProjectInvitation projectInvitation = projectInvitationRepository.findByToken(request.token());
+        Project project = projectService.findByProjectId(projectId);
+        MemberProject adminMemberProject = memberProjectRepository.findByProjectIdAndMemberId(projectId, request.adminId());
+        ProjectInvitation projectInvitation = projectInvitationRepository.findFirstByProjectAndEmailOrderByExpiryDateDesc(project, request.email())
+                .orElseThrow(() -> new ProjectException("존재하지 않는 초대입니다.", HttpStatus.BAD_REQUEST));
 
-        if (!memberProject.isAdmin()) {
+        if (adminMemberProject == null || !adminMemberProject.isAdmin()) {
             throw new ProjectException("권한이 없습니다.", HttpStatus.BAD_REQUEST);
         }
         if (projectInvitation.isAccepted()) {
             throw new ProjectException("이미 수락된 초대입니다.", HttpStatus.BAD_REQUEST);
-        }
-        if (!projectInvitation.getToken().equals(request.token())) {
-            throw new ProjectException("유효하지 않은 토큰입니다.", HttpStatus.BAD_REQUEST);
         }
 
         projectInvitationRepository.delete(projectInvitation);
         return projectMemberMapper.deleteInvitationSuccess();
     }
 }
+// 스케줄러로 유효기간 지나면 삭제 ?

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,13 +4,11 @@ spring:
       on-profile: local
 
   datasource:
-#    driver-class-name: com.mysql.cj.jdbc.Driver
+    #    driver-class-name: com.mysql.cj.jdbc.Driver
     driver-class-name: org.mariadb.jdbc.Driver
     url: ${MARIA_DATABASE_URL}
     username: ${MARIA_USER}
     password: ${MARIA_PASSWORD}
-
-    # HikariCP 커넥션 풀 설정
     hikari:
       maximum-pool-size: 20
       minimum-idle: 5
@@ -21,19 +19,31 @@ spring:
       pool-name: HikariCP-Local
       leak-detection-threshold: 60000
 
-  # JPA 로컬 설정
   jpa:
     hibernate:
-      ddl-auto: update  # 로컬에서는 자동 스키마 업데이트
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MariaDBDialect # mariadb
     #        dialect: org.hibernate.dialect.MySQL8Dialect # mysql
     show-sql: true
 
-  # actuator
-  management:
-    endpoints:
-      web:
-        exposure:
-          include: health
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_ADDRESS}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        debug: true
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health


### PR DESCRIPTION
## ✨ 개요
- 프로젝트 초대 생성
    - admin만 가능
    - admin 초대 불가
- 프로젝트 멤버 삭제
    - admin만 삭제 가능
    - admin 삭제 불가
- 프로젝트 초대 삭제
    - admin만 가능
- 프로젝트 멤버 상태 수정
    - admin만 가능
    - admin 권한 수정 불가

## ✅ 작업 내용
실제로 어떤 작업을 했는지 체크리스트로 작성해주세요.
- [x] 기능 개발
- [ ] 테스트 코드 작성
- [ ] 문서화
- [ ] 기타 작업

## 🔍 관련 이슈
관련된 이슈 번호를 작성해주세요.
- close #17 
